### PR TITLE
Add unique tab id helper

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,8 @@ export default [
         setTimeout: 'readonly',
         clearTimeout: 'readonly',
         localStorage: 'readonly',
+        navigator: 'readonly',
+        process: 'readonly',
         __dirname: 'readonly', // usado no vite.config.ts
       },
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,7 @@ import pluginJsxA11y from 'eslint-plugin-jsx-a11y'
 import prettier from 'eslint-config-prettier'
 
 export default [
+  { ignores: ['dist/**'] },
   js.configs.recommended,
 
   {
@@ -29,9 +30,10 @@ export default [
         setTimeout: 'readonly',
         clearTimeout: 'readonly',
         localStorage: 'readonly',
+        __dirname: 'readonly', // usado no vite.config.ts
+        crypto: 'readonly',
         navigator: 'readonly',
         process: 'readonly',
-        __dirname: 'readonly', // usado no vite.config.ts
       },
     },
     plugins: {

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -170,10 +170,11 @@ function Options(): React.ReactElement {
               {delayedTabItems.map((tab) => (
                 <tr key={tab.id}>
                   <td>
-                    <label aria-label='Select tab'>
+                    <label>
                       <input
                         type='checkbox'
                         className='checkbox'
+                        aria-label='Select tab'
                         checked={selectedTabs.includes(tab.id)}
                         onChange={() => toggleTabSelection(tab.id)}
                       />

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -144,10 +144,11 @@ function Options(): React.ReactElement {
             <thead>
               <tr>
                 <th className='w-12'>
-                  <label aria-label='Select all tabs'>
+                  <label>
                     <input
                       type='checkbox'
                       className='checkbox'
+                      aria-label='Select all tabs'
                       checked={selectedTabs.length === delayedTabItems.length && delayedTabItems.length > 0}
                       onChange={() =>
                         setSelectedTabs(

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,4 +1,5 @@
 import { DelayedTab } from '@types';
+import normalizeDelayedTabs from '@utils/normalizeDelayedTabs';
 import useTheme from '@utils/useTheme';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,7 +14,7 @@ function Options(): React.ReactElement {
   const [delayedTabItems, setDelayedTabs] = useState<DelayedTab[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<'tabs' | 'settings'>('tabs');
-  const [selectedTabs, setSelectedTabs] = useState<number[]>([]);
+  const [selectedTabs, setSelectedTabs] = useState<string[]>([]);
   const { theme, toggleTheme } = useTheme();
   const { t, i18n } = useTranslation();
 
@@ -22,7 +23,8 @@ function Options(): React.ReactElement {
       setLoading(true);
       const { delayedTabs = [] } =
         await chrome.storage.local.get('delayedTabs');
-      const sortedTabs = [...delayedTabs].sort(
+      const normalizedTabs = normalizeDelayedTabs(delayedTabs);
+      const sortedTabs = [...normalizedTabs].sort(
         (a, b) => a.wakeTime - b.wakeTime
       );
       setDelayedTabs(sortedTabs);
@@ -128,7 +130,7 @@ function Options(): React.ReactElement {
     }
   };
 
-  const toggleTabSelection = (tabId: number): void => {
+  const toggleTabSelection = (tabId: string): void => {
     setSelectedTabs(prev =>
       prev.includes(tabId)
         ? prev.filter(id => id !== tabId)
@@ -145,10 +147,12 @@ function Options(): React.ReactElement {
               <tr>
                 <th className='w-12'>
                   <label>
+                    <span className='sr-only'>Select all</span>
                     <input
                       type='checkbox'
                       className='checkbox'
-                      aria-label='Select all tabs'
+                    <label>
+                      <span className='sr-only'>Select tab</span>
                       checked={selectedTabs.length === delayedTabItems.length && delayedTabItems.length > 0}
                       onChange={() =>
                         setSelectedTabs(

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -41,7 +41,7 @@ function Options(): React.ReactElement {
     try {
       if (tab.url) {
         await chrome.tabs.create({ url: tab.url });
-        const updatedTabs = delayedTabItems.filter((t) => t.id !== tab.id);
+        const updatedTabs = delayedTabItems.filter((item) => item.id !== tab.id);
         await chrome.storage.local.set({ delayedTabs: updatedTabs });
         await chrome.alarms.clear(`delayed-tab-${tab.id}`);
         setDelayedTabs(updatedTabs);
@@ -54,7 +54,7 @@ function Options(): React.ReactElement {
 
   const removeTab = async (tab: DelayedTab): Promise<void> => {
     try {
-      const updatedTabs = delayedTabItems.filter((t) => t.id !== tab.id);
+      const updatedTabs = delayedTabItems.filter((item) => item.id !== tab.id);
       await chrome.storage.local.set({ delayedTabs: updatedTabs });
       await chrome.alarms.clear(`delayed-tab-${tab.id}`);
       setDelayedTabs(updatedTabs);
@@ -144,7 +144,7 @@ function Options(): React.ReactElement {
             <thead>
               <tr>
                 <th className='w-12'>
-                  <label>
+                  <label aria-label='Select all tabs'>
                     <input
                       type='checkbox'
                       className='checkbox'
@@ -169,7 +169,7 @@ function Options(): React.ReactElement {
               {delayedTabItems.map((tab) => (
                 <tr key={tab.id}>
                   <td>
-                    <label>
+                    <label aria-label='Select tab'>
                       <input
                         type='checkbox'
                         className='checkbox'

--- a/src/popup/views/CustomDelayView.tsx
+++ b/src/popup/views/CustomDelayView.tsx
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from '@tanstack/react-router';
 import React, { useEffect, useState } from 'react';
+import generateUniqueTabId from '@utils/generateUniqueTabId';
 import { useTranslation } from 'react-i18next';
 
 function CustomDelayView(): React.ReactElement {
@@ -96,9 +97,11 @@ function CustomDelayView(): React.ReactElement {
 
         for (const tab of tabsToDelay) {
           if (!tab.id) continue;
-          
+
+          const newTabId = generateUniqueTabId();
+
           const tabInfo = {
-            id: tab.id,
+            id: newTabId,
             url: tab.url,
             title: tab.title,
             favicon: tab.favIconUrl,

--- a/src/popup/views/MainView.tsx
+++ b/src/popup/views/MainView.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import useTheme from '../../utils/useTheme';
+import generateUniqueTabId from '@utils/generateUniqueTabId';
 
 interface DelaySettings {
   laterToday: number; // hours
@@ -410,9 +411,11 @@ function MainView(): React.ReactElement {
       
       for (const tab of tabsToDelay) {
         if (!tab.id) continue;
-        
+
+        const newTabId = generateUniqueTabId();
+
         const tabInfo = {
-          id: tab.id,
+          id: newTabId,
           url: tab.url,
           title: tab.title,
           favicon: tab.favIconUrl,

--- a/src/popup/views/ManageTabsView.tsx
+++ b/src/popup/views/ManageTabsView.tsx
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from '@tanstack/react-router';
 import { DelayedTab } from '@types';
+import normalizeDelayedTabs from '@utils/normalizeDelayedTabs';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -9,7 +10,7 @@ import useTheme from '../../utils/useTheme';
 function ManageTabsView(): React.ReactElement {
   const [delayedTabs, setDelayedTabs] = useState<DelayedTab[]>([]);
   const [loading, setLoading] = useState(true);
-  const [selectedTabs, setSelectedTabs] = useState<number[]>([]);
+  const [selectedTabs, setSelectedTabs] = useState<string[]>([]);
   const [selectMode, setSelectMode] = useState(false);
   const { theme, toggleTheme } = useTheme();
   const { t } = useTranslation();
@@ -19,7 +20,8 @@ function ManageTabsView(): React.ReactElement {
       try {
         setLoading(true);
         const { delayedTabs: storedTabs = [] } = await chrome.storage.local.get('delayedTabs');
-        const sortedTabs = [...storedTabs].sort(
+        const normalizedTabs = normalizeDelayedTabs(storedTabs);
+        const sortedTabs = [...normalizedTabs].sort(
           (a, b) => a.wakeTime - b.wakeTime
         );
         setDelayedTabs(sortedTabs);
@@ -37,7 +39,7 @@ function ManageTabsView(): React.ReactElement {
     try {
       if (tab.url) {
         await chrome.tabs.create({ url: tab.url });
-        const updatedTabs = delayedTabs.filter((tabItem) => tabItem.id !== tab.id);
+        const updatedTabs = delayedTabs.filter((item) => item.id !== tab.id);
         await chrome.storage.local.set({ delayedTabs: updatedTabs });
         await chrome.alarms.clear(`delayed-tab-${tab.id}`);
         setDelayedTabs(updatedTabs);
@@ -50,7 +52,7 @@ function ManageTabsView(): React.ReactElement {
 
   const removeTab = async (tab: DelayedTab): Promise<void> => {
     try {
-      const updatedTabs = delayedTabs.filter((tabItem) => tabItem.id !== tab.id);
+      const updatedTabs = delayedTabs.filter((item) => item.id !== tab.id);
       await chrome.storage.local.set({ delayedTabs: updatedTabs });
       await chrome.alarms.clear(`delayed-tab-${tab.id}`);
       setDelayedTabs(updatedTabs);
@@ -75,7 +77,7 @@ function ManageTabsView(): React.ReactElement {
     }
   };
 
-  const toggleSelectTab = (tabId: number): void => {
+  const toggleSelectTab = (tabId: string): void => {
     setSelectedTabs(prev => {
       if (prev.includes(tabId)) {
         return prev.filter(id => id !== tabId);
@@ -88,13 +90,13 @@ function ManageTabsView(): React.ReactElement {
   const wakeSelectedTabs = async (): Promise<void> => {
     try {
       for (const tabId of selectedTabs) {
-        const tab = delayedTabs.find((tabItem) => tabItem.id === tabId);
+        const tab = delayedTabs.find(item => item.id === tabId);
         if (tab && tab.url) {
           await chrome.tabs.create({ url: tab.url });
         }
       }
 
-      const updatedTabs = delayedTabs.filter((tabItem) => !selectedTabs.includes(tabItem.id));
+      const updatedTabs = delayedTabs.filter(tab => !selectedTabs.includes(tab.id));
       await chrome.storage.local.set({ delayedTabs: updatedTabs });
 
       for (const tabId of selectedTabs) {
@@ -110,7 +112,7 @@ function ManageTabsView(): React.ReactElement {
 
   const removeSelectedTabs = async (): Promise<void> => {
     try {
-      const updatedTabs = delayedTabs.filter((tabItem) => !selectedTabs.includes(tabItem.id));
+      const updatedTabs = delayedTabs.filter(tab => !selectedTabs.includes(tab.id));
       await chrome.storage.local.set({ delayedTabs: updatedTabs });
 
       for (const tabId of selectedTabs) {

--- a/src/popup/views/ManageTabsView.tsx
+++ b/src/popup/views/ManageTabsView.tsx
@@ -18,8 +18,8 @@ function ManageTabsView(): React.ReactElement {
     const loadDelayedTabs = async (): Promise<void> => {
       try {
         setLoading(true);
-        const { delayedTabs = [] } = await chrome.storage.local.get('delayedTabs');
-        const sortedTabs = [...delayedTabs].sort(
+        const { delayedTabs: storedTabs = [] } = await chrome.storage.local.get('delayedTabs');
+        const sortedTabs = [...storedTabs].sort(
           (a, b) => a.wakeTime - b.wakeTime
         );
         setDelayedTabs(sortedTabs);
@@ -37,7 +37,7 @@ function ManageTabsView(): React.ReactElement {
     try {
       if (tab.url) {
         await chrome.tabs.create({ url: tab.url });
-        const updatedTabs = delayedTabs.filter((t) => t.id !== tab.id);
+        const updatedTabs = delayedTabs.filter((tabItem) => tabItem.id !== tab.id);
         await chrome.storage.local.set({ delayedTabs: updatedTabs });
         await chrome.alarms.clear(`delayed-tab-${tab.id}`);
         setDelayedTabs(updatedTabs);
@@ -50,7 +50,7 @@ function ManageTabsView(): React.ReactElement {
 
   const removeTab = async (tab: DelayedTab): Promise<void> => {
     try {
-      const updatedTabs = delayedTabs.filter((t) => t.id !== tab.id);
+      const updatedTabs = delayedTabs.filter((tabItem) => tabItem.id !== tab.id);
       await chrome.storage.local.set({ delayedTabs: updatedTabs });
       await chrome.alarms.clear(`delayed-tab-${tab.id}`);
       setDelayedTabs(updatedTabs);
@@ -88,13 +88,13 @@ function ManageTabsView(): React.ReactElement {
   const wakeSelectedTabs = async (): Promise<void> => {
     try {
       for (const tabId of selectedTabs) {
-        const tab = delayedTabs.find(t => t.id === tabId);
+        const tab = delayedTabs.find((tabItem) => tabItem.id === tabId);
         if (tab && tab.url) {
           await chrome.tabs.create({ url: tab.url });
         }
       }
 
-      const updatedTabs = delayedTabs.filter(tab => !selectedTabs.includes(tab.id));
+      const updatedTabs = delayedTabs.filter((tabItem) => !selectedTabs.includes(tabItem.id));
       await chrome.storage.local.set({ delayedTabs: updatedTabs });
 
       for (const tabId of selectedTabs) {
@@ -110,7 +110,7 @@ function ManageTabsView(): React.ReactElement {
 
   const removeSelectedTabs = async (): Promise<void> => {
     try {
-      const updatedTabs = delayedTabs.filter(tab => !selectedTabs.includes(tab.id));
+      const updatedTabs = delayedTabs.filter((tabItem) => !selectedTabs.includes(tabItem.id));
       await chrome.storage.local.set({ delayedTabs: updatedTabs });
 
       for (const tabId of selectedTabs) {

--- a/src/popup/views/RecurringDelayView.tsx
+++ b/src/popup/views/RecurringDelayView.tsx
@@ -2,6 +2,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from '@tanstack/react-router';
 import { DelayedTab, RecurrencePattern } from '@types';
 import React, { useEffect, useId, useState } from 'react';
+import generateUniqueTabId from '@utils/generateUniqueTabId';
 import { useTranslation } from 'react-i18next';
 
 function FormControl({
@@ -185,9 +186,11 @@ function RecurringDelayView(): React.ReactElement {
         
         for (const tab of tabsToDelay) {
           if (!tab.id) continue;
-          
+
+          const newTabId = generateUniqueTabId();
+
           const tabInfo: DelayedTab = {
-            id: tab.id,
+            id: newTabId,
             url: tab.url,
             title: tab.title,
             favicon: tab.favIconUrl,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,7 @@ export interface RecurrencePattern {
 }
 
 export interface DelayedTab {
-  id: number;
+  id: string;
   url?: string;
   title?: string;
   favicon?: string;

--- a/src/utils/generateUniqueTabId.ts
+++ b/src/utils/generateUniqueTabId.ts
@@ -1,0 +1,9 @@
+export default function generateUniqueTabId(): string {
+  if (
+    typeof globalThis.crypto !== 'undefined' &&
+    typeof globalThis.crypto.randomUUID === 'function'
+  ) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+}

--- a/src/utils/normalizeDelayedTabs.ts
+++ b/src/utils/normalizeDelayedTabs.ts
@@ -1,0 +1,8 @@
+import { DelayedTab } from '@types';
+
+export default function normalizeDelayedTabs(tabs: DelayedTab[]): DelayedTab[] {
+  return tabs.map((tab) => ({
+    ...tab,
+    id: String(tab.id),
+  }));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,11 @@
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": [
+      "chrome",
+      "node"
+    ]
   },
   "include": [
     "src/**/*",
@@ -41,9 +45,5 @@
   "exclude": [
     "node_modules",
     "dist"
-  ],
-  "types": [
-    "chrome",
-//    "node"
   ]
 }


### PR DESCRIPTION
## Summary
- add generateUniqueTabId helper
- fix lint errors in options and popup views
- allow ESLint globals for navigator and process

## Testing
- `pnpm build`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68444fcb43b0832ab793af13562363a6