### PR TITLE
Fix eslint globals

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ export default [
         setTimeout: 'readonly',
         clearTimeout: 'readonly',
         localStorage: 'readonly',
+        crypto: 'readonly',
         __dirname: 'readonly', // usado no vite.config.ts
       },
     },


### PR DESCRIPTION
## Summary
- add `crypto` to the ESLint globals list

## Testing
- `pnpm install`
- `npm run lint` *(fails: 'navigator' is not defined and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68444fc87a00832ab280a08564a6340f