### PR TITLE
Normalize delayed tab IDs as strings

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,7 @@ export interface RecurrencePattern {
 }
 
 export interface DelayedTab {
-  id: number;
+  id: number | string;
   url?: string;
   title?: string;
   favicon?: string;


### PR DESCRIPTION
## Summary
- normalize tab IDs from storage in `background`, `Options`, and `ManageTabsView`
- update comparisons in `background` to compare stringified IDs
- store selected tab IDs as strings
- allow `DelayedTab.id` to hold a string

## Testing
- `pnpm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68444fc9aec8832aa44cdf9d5994175c