### PR TITLE
Fix missing endDate translations

### DIFF
--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -99,6 +99,7 @@
     "wakeUpTime": "Wake up time",
     "timeLeft": "Time left",
     "delayedUntil": "Delayed until",
+    "endDate": "End date",
     "now": "Now",
     "select": "Select",
     "cancel": "Cancel",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -99,6 +99,7 @@
     "wakeUpTime": "Hora de despertar",
     "timeLeft": "Tiempo restante",
     "delayedUntil": "Aplazada hasta",
+    "endDate": "Fecha de finalización",
     "now": "Ahora",
     "select": "Seleccionar",
     "cancel": "Cancelar",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -99,6 +99,7 @@
     "wakeUpTime": "Horário de despertar",
     "timeLeft": "Tempo restante",
     "delayedUntil": "Adiada até",
+    "endDate": "Data final",
     "now": "Agora",
     "select": "Selecionar",
     "cancel": "Cancelar",


### PR DESCRIPTION
## Summary
- add translation strings for `manageTabs.endDate` in English, Spanish, and Portuguese

## Testing
- `pnpm install`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684cc765afd4832ab21197c16f8bf484