### PR TITLE
feat: improve custom delay scheduling

### DIFF
--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -73,7 +73,11 @@ function Onboarding({ onComplete }: OnboardingProps): React.ReactElement {
             </p>
             <div className='w-full max-w-xs rounded-lg bg-base-200 p-3'>
               <ul className='space-y-2 text-left text-base'>
-                <li>{t('popup.delayOptions.laterToday', { hours: 3 })}</li>
+                <li>
+                  {t('popup.delayOptions.laterToday', {
+                    duration: t('popup.delayDuration.hours', { count: 3 }),
+                  })}
+                </li>
                 <li>{t('popup.delayOptions.tomorrow', { time: '09:00' })}</li>
                 <li>
                   {t('popup.delayOptions.weekend', {

--- a/src/domain/delaySettings.ts
+++ b/src/domain/delaySettings.ts
@@ -2,6 +2,7 @@ import { DelaySettings } from '@types';
 
 export const defaultDelaySettings: DelaySettings = {
   laterToday: 3,
+  laterTodayMinutes: 0,
   tonightTime: '18:00',
   tomorrowTime: '09:00',
   weekendDay: 'saturday',
@@ -14,11 +15,40 @@ export const defaultDelaySettings: DelaySettings = {
   somedayMaxMonths: 12,
 };
 
+function clampNumber(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), min), max);
+}
+
 export function normalizeDelaySettings(
   settings?: Partial<DelaySettings> | null
 ): DelaySettings {
+  const laterToday = clampNumber(
+    settings?.laterToday,
+    defaultDelaySettings.laterToday,
+    0,
+    12
+  );
+  const laterTodayMinutes = clampNumber(
+    settings?.laterTodayMinutes,
+    defaultDelaySettings.laterTodayMinutes,
+    0,
+    59
+  );
+
   return {
     ...defaultDelaySettings,
     ...settings,
+    laterToday: laterToday === 0 && laterTodayMinutes === 0 ? 0 : laterToday,
+    laterTodayMinutes:
+      laterToday === 0 && laterTodayMinutes === 0 ? 1 : laterTodayMinutes,
   };
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -83,6 +83,7 @@
     "selectDateTime": "Select Date & Time",
     "delayFor": "Delay For",
     "or": "or",
+    "invalidDate": "It is not possible to choose a past time.",
     "relative": {
       "days": "Days",
       "hours": "Hours",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -43,7 +43,7 @@
       "window": "Current Window"
     },
     "delayOptions": {
-      "laterToday": "Later today (in {{hours}} hours)",
+      "laterToday": "In {{duration}}",
       "tonight": "Tonight (at {{time}})",
       "tomorrow": "Tomorrow (at {{time}})",
       "weekend": "This weekend ({{day}}, {{time}})",
@@ -52,6 +52,12 @@
       "someday": "Someday (random)",
       "custom": "Custom date & time",
       "recurring": "Recurring"
+    },
+    "delayDuration": {
+      "hour": "{{count}} hour",
+      "hours": "{{count}} hours",
+      "minute": "{{count}} minute",
+      "minutes": "{{count}} minutes"
     },
     "weekdays": {
       "sunday": "Sunday",
@@ -100,6 +106,7 @@
     "defaultDelayOptions": "Default Delay Options",
     "laterToday": "Later Today",
     "hours": "hours",
+    "minutes": "minutes",
     "tonight": "Tonight",
     "tomorrow": "Tomorrow",
     "weekend": "This Weekend",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -81,6 +81,13 @@
   "customDelay": {
     "title": "Custom Delay",
     "selectDateTime": "Select Date & Time",
+    "delayFor": "Delay For",
+    "or": "or",
+    "relative": {
+      "days": "Days",
+      "hours": "Hours",
+      "minutes": "Minutes"
+    },
     "delayTab": "Delay Tab"
   },
   "recurringDelay": {

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -81,6 +81,13 @@
   "customDelay": {
     "title": "Aplazamiento Personalizado",
     "selectDateTime": "Seleccionar Fecha y Hora",
+    "delayFor": "Aplazar por",
+    "or": "o",
+    "relative": {
+      "days": "Días",
+      "hours": "Horas",
+      "minutes": "Minutos"
+    },
     "delayTab": "Aplazar pestaña"
   },
   "recurringDelay": {

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -43,7 +43,7 @@
       "window": "Ventana Actual"
     },
     "delayOptions": {
-      "laterToday": "Hoy más tarde (en {{hours}} horas)",
+      "laterToday": "En {{duration}}",
       "tonight": "Esta noche (a las {{time}})",
       "tomorrow": "Mañana ({{time}})",
       "weekend": "Fin de semana ({{day}}, {{time}})",
@@ -52,6 +52,12 @@
       "someday": "Algún Día (aleatorio)",
       "custom": "Fecha personalizada",
       "recurring": "Repetir"
+    },
+    "delayDuration": {
+      "hour": "{{count}} hora",
+      "hours": "{{count}} horas",
+      "minute": "{{count}} minuto",
+      "minutes": "{{count}} minutos"
     },
     "weekdays": {
       "sunday": "Domingo",
@@ -100,6 +106,7 @@
     "defaultDelayOptions": "Opciones predeterminadas de aplazamiento",
     "laterToday": "Hoy más tarde",
     "hours": "horas",
+    "minutes": "minutos",
     "tonight": "Esta noche",
     "tomorrow": "Mañana",
     "weekend": "Fin de semana",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -83,6 +83,7 @@
     "selectDateTime": "Seleccionar Fecha y Hora",
     "delayFor": "Aplazar por",
     "or": "o",
+    "invalidDate": "No es posible elegir una hora pasada.",
     "relative": {
       "days": "Días",
       "hours": "Horas",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -83,6 +83,7 @@
     "selectDateTime": "Selecione Data e Hora",
     "delayFor": "Adiar por",
     "or": "ou",
+    "invalidDate": "Nao e possivel escolher um horario passado.",
     "relative": {
       "days": "Dias",
       "hours": "Horas",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -81,6 +81,13 @@
   "customDelay": {
     "title": "Adiamento Personalizado",
     "selectDateTime": "Selecione Data e Hora",
+    "delayFor": "Adiar por",
+    "or": "ou",
+    "relative": {
+      "days": "Dias",
+      "hours": "Horas",
+      "minutes": "Minutos"
+    },
     "delayTab": "Adiar Aba"
   },
   "recurringDelay": {

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -43,7 +43,7 @@
       "window": "Janela Atual"
     },
     "delayOptions": {
-      "laterToday": "Hoje Mais Tarde (em {{hours}} horas)",
+      "laterToday": "Em {{duration}}",
       "tonight": "Esta Noite (às {{time}})",
       "tomorrow": "Amanhã (às {{time}})",
       "weekend": "Este Fim de Semana ({{day}}, {{time}})",
@@ -52,6 +52,12 @@
       "someday": "Algum Dia (aleatório)",
       "custom": "Data e Hora Personalizada",
       "recurring": "Recorrente"
+    },
+    "delayDuration": {
+      "hour": "{{count}} hora",
+      "hours": "{{count}} horas",
+      "minute": "{{count}} minuto",
+      "minutes": "{{count}} minutos"
     },
     "weekdays": {
       "sunday": "Domingo",
@@ -100,6 +106,7 @@
     "defaultDelayOptions": "Opções de Adiamento Padrão",
     "laterToday": "Hoje Mais Tarde",
     "hours": "horas",
+    "minutes": "minutos",
     "tonight": "Esta Noite",
     "tomorrow": "Amanhã",
     "weekend": "Este Fim de Semana",

--- a/src/pages/options/DelaySettings.tsx
+++ b/src/pages/options/DelaySettings.tsx
@@ -11,6 +11,9 @@ const getRadioClasses = (isPopup: boolean): string =>
 const getSelectClasses = (isPopup: boolean): string =>
   `select select-bordered ${isPopup ? 'rounded-lg bg-base-100/70 shadow-sm transition-all duration-200 hover:bg-base-100' : ''}`;
 
+const parseNumberInput = (value: string, fallback: number): number =>
+  Number.parseInt(value, 10) || fallback;
+
 interface DelaySettingsComponentProps {
   isPopup?: boolean;
 }
@@ -61,20 +64,37 @@ function DelaySettingsComponent({
               </span>
             </label>
             <div className='flex items-center'>
-              <input
-                type='number'
-                className={`${getInputClasses(isPopup)} w-20`}
-                min='1'
-                max='12'
-                value={settings.laterToday}
-                onChange={(event) =>
-                  updateSetting(
-                    'laterToday',
-                    parseInt(event.target.value, 10) || 1
-                  )
-                }
-              />
-              <span className='ml-2'>{t('settings.hours')}</span>
+              <div className='flex flex-wrap items-center gap-2'>
+                <input
+                  type='number'
+                  className={`${getInputClasses(isPopup)} w-20`}
+                  min='0'
+                  max='12'
+                  value={settings.laterToday}
+                  onChange={(event) =>
+                    updateSetting(
+                      'laterToday',
+                      parseNumberInput(event.target.value, 0)
+                    )
+                  }
+                />
+                <span>{t('settings.hours')}</span>
+                <input
+                  type='number'
+                  className={`${getInputClasses(isPopup)} w-20`}
+                  min='0'
+                  max='59'
+                  step='5'
+                  value={settings.laterTodayMinutes}
+                  onChange={(event) =>
+                    updateSetting(
+                      'laterTodayMinutes',
+                      parseNumberInput(event.target.value, 0)
+                    )
+                  }
+                />
+                <span>{t('settings.minutes')}</span>
+              </div>
             </div>
           </div>
 

--- a/src/pages/popup/views/CustomDelayView.tsx
+++ b/src/pages/popup/views/CustomDelayView.tsx
@@ -2,6 +2,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from '@tanstack/react-router';
 import useTabSelection from '@hooks/useTabSelection';
 import { scheduleTabs } from '@utils/delayedTabsRuntime';
+import { formatDateTimeLocalInput } from '@utils/dateTime';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -16,8 +17,9 @@ function CustomDelayView(): React.ReactElement {
     selectedMode,
     tabsToDelay,
   } = useTabSelection();
+  const minCustomDate = formatDateTimeLocalInput(new Date());
   const [customDate, setCustomDate] = useState(
-    new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+    formatDateTimeLocalInput(new Date(Date.now() + 60 * 1000))
   );
 
   const handleDelay = async (): Promise<void> => {
@@ -115,7 +117,7 @@ function CustomDelayView(): React.ReactElement {
             className='input input-bordered w-full border-none bg-base-100/50 shadow-sm transition-all duration-200 focus:bg-base-100/80'
             value={customDate}
             onChange={(event) => setCustomDate(event.target.value)}
-            min={new Date().toISOString().slice(0, 16)}
+            min={minCustomDate}
           />
         </div>
 

--- a/src/pages/popup/views/CustomDelayView.tsx
+++ b/src/pages/popup/views/CustomDelayView.tsx
@@ -66,6 +66,7 @@ function CustomDelayView(): React.ReactElement {
   const [relativeDelay, setRelativeDelay] = useState<RelativeDelayInputValues>(
     toRelativeDelayInputValues(getRelativeDelayValues(initialDate, new Date()))
   );
+  const [dateError, setDateError] = useState<string | null>(null);
 
   const syncFromDate = (nextDate: Date): void => {
     const now = new Date();
@@ -81,6 +82,7 @@ function CustomDelayView(): React.ReactElement {
 
   const handleDateChange = (value: string): void => {
     setCustomDate(value);
+    setDateError(null);
 
     const nextDate = new Date(value);
 
@@ -95,12 +97,19 @@ function CustomDelayView(): React.ReactElement {
 
   const handleDateBlur = (): void => {
     const nextDate = new Date(customDate);
+    const minimumDate = getMinimumCustomDelayDate(new Date());
 
     if (!isDateValid(nextDate)) {
-      syncFromDate(getMinimumCustomDelayDate(new Date()));
+      setDateError(t('customDelay.invalidDate'));
       return;
     }
 
+    if (nextDate.getTime() < minimumDate.getTime()) {
+      setDateError(t('customDelay.invalidDate'));
+      return;
+    }
+
+    setDateError(null);
     syncFromDate(nextDate);
   };
 
@@ -108,6 +117,8 @@ function CustomDelayView(): React.ReactElement {
     field: keyof RelativeDelayInputValues,
     value: string
   ): void => {
+    setDateError(null);
+
     const sanitizedValue = value.replace(/\D/g, '');
     const nextRelativeDelay = {
       ...relativeDelay,
@@ -128,16 +139,16 @@ function CustomDelayView(): React.ReactElement {
   const handleDelay = async (): Promise<void> => {
     const nextDate = new Date(customDate);
 
-    if (tabsToDelay.length === 0 || !isDateValid(nextDate)) {
+    if (
+      tabsToDelay.length === 0 ||
+      !isDateValid(nextDate) ||
+      nextDate.getTime() < getMinimumCustomDelayDate(new Date()).getTime()
+    ) {
       return;
     }
 
-    const normalizedDate = new Date(
-      Math.max(nextDate.getTime(), getMinimumCustomDelayDate(new Date()).getTime())
-    );
-
     await persistSelectedMode();
-    await scheduleTabs(tabsToDelay, normalizedDate.getTime());
+    await scheduleTabs(tabsToDelay, nextDate.getTime());
     window.close();
   };
 
@@ -231,12 +242,15 @@ function CustomDelayView(): React.ReactElement {
           </label>
           <input
             type='datetime-local'
-            className='input input-bordered w-full border-none bg-base-100/50 shadow-sm transition-all duration-200 focus:bg-base-100/80'
+            className={`input input-bordered w-full border-none bg-base-100/50 shadow-sm transition-all duration-200 focus:bg-base-100/80 ${dateError ? 'input-error' : ''}`}
             value={customDate}
             onChange={(event) => handleDateChange(event.target.value)}
             onBlur={handleDateBlur}
             min={formatDateTimeLocalInput(minimumCustomDate)}
           />
+          {dateError && (
+            <span className='mt-2 text-xs text-error'>{dateError}</span>
+          )}
         </div>
 
         <div className='my-4 flex items-center gap-3'>

--- a/src/pages/popup/views/CustomDelayView.tsx
+++ b/src/pages/popup/views/CustomDelayView.tsx
@@ -1,10 +1,52 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from '@tanstack/react-router';
 import useTabSelection from '@hooks/useTabSelection';
+import type { RelativeDelayValues } from '@utils/dateTime';
 import { scheduleTabs } from '@utils/delayedTabsRuntime';
-import { formatDateTimeLocalInput } from '@utils/dateTime';
+import {
+  formatDateTimeLocalInput,
+  getDateFromRelativeDelay,
+  getMinimumCustomDelayDate,
+  getRelativeDelayValues,
+} from '@utils/dateTime';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+
+interface RelativeDelayInputValues {
+  days: string;
+  hours: string;
+  minutes: string;
+}
+
+const relativeDelayFields: Array<keyof RelativeDelayInputValues> = [
+  'days',
+  'hours',
+  'minutes',
+];
+
+function toRelativeDelayInputValues(
+  values: RelativeDelayValues
+): RelativeDelayInputValues {
+  return {
+    days: String(values.days),
+    hours: String(values.hours),
+    minutes: String(values.minutes),
+  };
+}
+
+function parseRelativeDelayValue(value: string): number {
+  const parsedValue = Number.parseInt(value, 10);
+
+  if (Number.isNaN(parsedValue) || parsedValue < 0) {
+    return 0;
+  }
+
+  return parsedValue;
+}
+
+function isDateValid(date: Date): boolean {
+  return !Number.isNaN(date.getTime());
+}
 
 function CustomDelayView(): React.ReactElement {
   const { t } = useTranslation();
@@ -17,20 +59,95 @@ function CustomDelayView(): React.ReactElement {
     selectedMode,
     tabsToDelay,
   } = useTabSelection();
-  const minCustomDate = formatDateTimeLocalInput(new Date());
+  const initialDate = getMinimumCustomDelayDate(new Date());
   const [customDate, setCustomDate] = useState(
-    formatDateTimeLocalInput(new Date(Date.now() + 60 * 1000))
+    formatDateTimeLocalInput(initialDate)
+  );
+  const [relativeDelay, setRelativeDelay] = useState<RelativeDelayInputValues>(
+    toRelativeDelayInputValues(getRelativeDelayValues(initialDate, new Date()))
   );
 
-  const handleDelay = async (): Promise<void> => {
-    if (tabsToDelay.length === 0) {
+  const syncFromDate = (nextDate: Date): void => {
+    const now = new Date();
+    const normalizedDate = new Date(
+      Math.max(nextDate.getTime(), getMinimumCustomDelayDate(now).getTime())
+    );
+
+    setCustomDate(formatDateTimeLocalInput(normalizedDate));
+    setRelativeDelay(
+      toRelativeDelayInputValues(getRelativeDelayValues(normalizedDate, now))
+    );
+  };
+
+  const handleDateChange = (value: string): void => {
+    setCustomDate(value);
+
+    const nextDate = new Date(value);
+
+    if (!isDateValid(nextDate)) {
       return;
     }
 
+    setRelativeDelay(
+      toRelativeDelayInputValues(getRelativeDelayValues(nextDate, new Date()))
+    );
+  };
+
+  const handleDateBlur = (): void => {
+    const nextDate = new Date(customDate);
+
+    if (!isDateValid(nextDate)) {
+      syncFromDate(getMinimumCustomDelayDate(new Date()));
+      return;
+    }
+
+    syncFromDate(nextDate);
+  };
+
+  const handleRelativeDelayChange = (
+    field: keyof RelativeDelayInputValues,
+    value: string
+  ): void => {
+    const sanitizedValue = value.replace(/\D/g, '');
+    const nextRelativeDelay = {
+      ...relativeDelay,
+      [field]: sanitizedValue,
+    };
+    const nextDate = getDateFromRelativeDelay(
+      {
+        days: parseRelativeDelayValue(nextRelativeDelay.days),
+        hours: parseRelativeDelayValue(nextRelativeDelay.hours),
+        minutes: parseRelativeDelayValue(nextRelativeDelay.minutes),
+      },
+      new Date()
+    );
+
+    syncFromDate(nextDate);
+  };
+
+  const handleDelay = async (): Promise<void> => {
+    const nextDate = new Date(customDate);
+
+    if (tabsToDelay.length === 0 || !isDateValid(nextDate)) {
+      return;
+    }
+
+    const normalizedDate = new Date(
+      Math.max(nextDate.getTime(), getMinimumCustomDelayDate(new Date()).getTime())
+    );
+
     await persistSelectedMode();
-    await scheduleTabs(tabsToDelay, new Date(customDate).getTime());
+    await scheduleTabs(tabsToDelay, normalizedDate.getTime());
     window.close();
   };
+
+  const selectedDate = new Date(customDate);
+  const isCustomDateValid = isDateValid(selectedDate);
+  const minimumCustomDate = getMinimumCustomDelayDate(new Date());
+  const canDelay =
+    tabsToDelay.length > 0 &&
+    isCustomDateValid &&
+    selectedDate.getTime() >= minimumCustomDate.getTime();
 
   if (loading) {
     return (
@@ -116,9 +233,47 @@ function CustomDelayView(): React.ReactElement {
             type='datetime-local'
             className='input input-bordered w-full border-none bg-base-100/50 shadow-sm transition-all duration-200 focus:bg-base-100/80'
             value={customDate}
-            onChange={(event) => setCustomDate(event.target.value)}
-            min={minCustomDate}
+            onChange={(event) => handleDateChange(event.target.value)}
+            onBlur={handleDateBlur}
+            min={formatDateTimeLocalInput(minimumCustomDate)}
           />
+        </div>
+
+        <div className='my-4 flex items-center gap-3'>
+          <div className='h-px flex-1 bg-base-content/10' />
+          <span className='text-xs font-medium uppercase tracking-wide text-base-content/50'>
+            {t('customDelay.or')}
+          </span>
+          <div className='h-px flex-1 bg-base-content/10' />
+        </div>
+
+        <div>
+          <label className='label'>
+            <span className='label-text font-medium'>
+              {t('customDelay.delayFor')}
+            </span>
+          </label>
+          <div className='grid grid-cols-3 gap-2'>
+            {relativeDelayFields.map((field) => (
+              <label key={field} className='form-control'>
+                <span className='mb-2 text-xs font-medium text-base-content/70'>
+                  {t(`customDelay.relative.${field}`)}
+                </span>
+                <input
+                  type='number'
+                  min='0'
+                  inputMode='numeric'
+                  className='input input-bordered w-full border-none bg-base-100/50 text-center shadow-sm transition-all duration-200 focus:bg-base-100/80'
+                  value={relativeDelay[field]}
+                  onFocus={(event) => event.currentTarget.select()}
+                  onClick={(event) => event.currentTarget.select()}
+                  onChange={(event) =>
+                    handleRelativeDelayChange(field, event.target.value)
+                  }
+                />
+              </label>
+            ))}
+          </div>
         </div>
 
         <div className='card-actions mt-6 justify-end'>
@@ -126,7 +281,7 @@ function CustomDelayView(): React.ReactElement {
             type='button'
             className='btn btn-primary border-none shadow-sm transition-all duration-200 hover:shadow'
             onClick={() => void handleDelay()}
-            disabled={tabsToDelay.length === 0 || !customDate}
+            disabled={!canDelay}
           >
             {t('customDelay.delayTab')}
           </button>

--- a/src/pages/popup/views/MainView.tsx
+++ b/src/pages/popup/views/MainView.tsx
@@ -56,6 +56,7 @@ function MainView(): React.ReactElement {
       option.calculateTime?.() ??
       Date.now() +
         (option.hours ? option.hours * 60 * 60 * 1000 : 0) +
+        (option.minutes ? option.minutes * 60 * 1000 : 0) +
         (option.days ? option.days * 24 * 60 * 60 * 1000 : 0);
 
     await scheduleTabs(tabsToDelay, wakeTime);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export type ThemePreference = 'light' | 'dark';
 
 export interface DelaySettings {
   laterToday: number;
+  laterTodayMinutes: number;
   tonightTime: string;
   tomorrowTime: string;
   weekendDay: 'saturday' | 'sunday';
@@ -22,6 +23,7 @@ export interface DelayOption {
   id: string;
   label: string;
   hours?: number;
+  minutes?: number;
   days?: number;
   custom?: boolean;
   calculateTime?: () => number;

--- a/src/utils/dateTime.test.ts
+++ b/src/utils/dateTime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { formatTimeLeft } from './dateTime';
+import { formatDateTimeLocalInput, formatTimeLeft } from './dateTime';
 
 const labels = {
   day: 'd',
@@ -10,6 +10,12 @@ const labels = {
 };
 
 describe('dateTime', () => {
+  it('formats dates for datetime-local inputs in local time', () => {
+    const date = new Date(2026, 2, 18, 13, 5, 27);
+
+    expect(formatDateTimeLocalInput(date)).toBe('2026-03-18T13:05');
+  });
+
   it('formats overdue timestamps as now', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-18T10:00:00.000Z'));

--- a/src/utils/dateTime.test.ts
+++ b/src/utils/dateTime.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { formatDateTimeLocalInput, formatTimeLeft } from './dateTime';
+import {
+  formatDateTimeLocalInput,
+  formatTimeLeft,
+  getDateFromRelativeDelay,
+  getMinimumCustomDelayDate,
+  getRelativeDelayValues,
+} from './dateTime';
 
 const labels = {
   day: 'd',
@@ -14,6 +20,81 @@ describe('dateTime', () => {
     const date = new Date(2026, 2, 18, 13, 5, 27);
 
     expect(formatDateTimeLocalInput(date)).toBe('2026-03-18T13:05');
+  });
+
+  it('rounds the minimum custom delay date to the next minute', () => {
+    const now = new Date('2026-03-18T10:00:45.000Z');
+
+    expect(getMinimumCustomDelayDate(now).toISOString()).toBe(
+      '2026-03-18T10:01:00.000Z'
+    );
+  });
+
+  it('derives relative delay values from a target date', () => {
+    const now = new Date('2026-03-18T10:00:00.000Z');
+    const targetDate = new Date('2026-03-20T13:15:00.000Z');
+
+    expect(getRelativeDelayValues(targetDate, now)).toEqual({
+      days: 2,
+      hours: 3,
+      minutes: 15,
+    });
+  });
+
+  it('derives relative delay values from the current minute instead of raw seconds', () => {
+    const now = new Date('2026-03-18T10:00:45.000Z');
+    const targetDate = new Date('2026-03-18T10:02:00.000Z');
+
+    expect(getRelativeDelayValues(targetDate, now)).toEqual({
+      days: 0,
+      hours: 0,
+      minutes: 2,
+    });
+  });
+
+  it('builds a target date from relative delay values', () => {
+    const now = new Date('2026-03-18T10:00:45.000Z');
+
+    expect(
+      getDateFromRelativeDelay(
+        {
+          days: 1,
+          hours: 2,
+          minutes: 30,
+        },
+        now
+      ).toISOString()
+    ).toBe('2026-03-19T12:30:00.000Z');
+  });
+
+  it('builds target dates from the current minute boundary', () => {
+    const now = new Date('2026-03-18T10:00:45.000Z');
+
+    expect(
+      getDateFromRelativeDelay(
+        {
+          days: 0,
+          hours: 0,
+          minutes: 2,
+        },
+        now
+      ).toISOString()
+    ).toBe('2026-03-18T10:02:00.000Z');
+  });
+
+  it('clamps relative delays below one minute to the minimum custom date', () => {
+    const now = new Date('2026-03-18T10:00:45.000Z');
+
+    expect(
+      getDateFromRelativeDelay(
+        {
+          days: 0,
+          hours: 0,
+          minutes: 0,
+        },
+        now
+      ).toISOString()
+    ).toBe('2026-03-18T10:01:00.000Z');
   });
 
   it('formats overdue timestamps as now', () => {

--- a/src/utils/dateTime.ts
+++ b/src/utils/dateTime.ts
@@ -5,8 +5,22 @@ interface TimeLeftLabels {
   now: string;
 }
 
+export interface RelativeDelayValues {
+  days: number;
+  hours: number;
+  minutes: number;
+}
+
 function padDateTimeSegment(value: number): string {
   return String(value).padStart(2, '0');
+}
+
+function getCurrentMinuteDate(now: Date): Date {
+  const currentMinuteDate = new Date(now);
+
+  currentMinuteDate.setSeconds(0, 0);
+
+  return currentMinuteDate;
 }
 
 function shouldUseHour12(locale: string): boolean {
@@ -48,6 +62,47 @@ export function formatDateTimeLocalInput(date: Date): string {
   const minutes = padDateTimeSegment(date.getMinutes());
 
   return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+export function getMinimumCustomDelayDate(now: Date): Date {
+  const minDate = new Date(now);
+
+  minDate.setSeconds(0, 0);
+  minDate.setMinutes(minDate.getMinutes() + 1);
+
+  return minDate;
+}
+
+export function getRelativeDelayValues(
+  targetDate: Date,
+  now: Date
+): RelativeDelayValues {
+  const baseDate = getCurrentMinuteDate(now);
+  const totalMinutes = Math.max(
+    0,
+    Math.round((targetDate.getTime() - baseDate.getTime()) / (1000 * 60))
+  );
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const minutes = totalMinutes % 60;
+
+  return { days, hours, minutes };
+}
+
+export function getDateFromRelativeDelay(
+  values: RelativeDelayValues,
+  now: Date
+): Date {
+  const totalMinutes = values.days * 24 * 60 + values.hours * 60 + values.minutes;
+  const baseDate = getCurrentMinuteDate(now);
+  const targetDate = new Date(baseDate.getTime() + totalMinutes * 60 * 1000);
+  const minimumDate = getMinimumCustomDelayDate(now);
+
+  if (targetDate.getTime() < minimumDate.getTime()) {
+    return minimumDate;
+  }
+
+  return targetDate;
 }
 
 export function formatTimeLeft(

--- a/src/utils/dateTime.ts
+++ b/src/utils/dateTime.ts
@@ -5,6 +5,10 @@ interface TimeLeftLabels {
   now: string;
 }
 
+function padDateTimeSegment(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
 function shouldUseHour12(locale: string): boolean {
   return locale.startsWith('en');
 }
@@ -34,6 +38,16 @@ export function formatClockTime(timestamp: number, locale: string): string {
     minute: '2-digit',
     hour12: shouldUseHour12(locale),
   }).format(new Date(timestamp));
+}
+
+export function formatDateTimeLocalInput(date: Date): string {
+  const year = date.getFullYear();
+  const month = padDateTimeSegment(date.getMonth() + 1);
+  const day = padDateTimeSegment(date.getDate());
+  const hours = padDateTimeSegment(date.getHours());
+  const minutes = padDateTimeSegment(date.getMinutes());
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
 }
 
 export function formatTimeLeft(

--- a/src/utils/delayPresets.test.ts
+++ b/src/utils/delayPresets.test.ts
@@ -1,12 +1,24 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  calculateLaterTodayWakeTime,
   calculateNextMonthWakeTime,
   calculateNextWeekWakeTime,
   createPresetDelayOptions,
 } from './delayPresets';
 
 describe('delayPresets', () => {
+  it('uses hours and minutes when calculating later today wake time', () => {
+    const now = new Date('2026-03-18T10:15:00.000Z');
+
+    expect(calculateLaterTodayWakeTime(now, 0, 15)).toBe(
+      new Date('2026-03-18T10:30:00.000Z').getTime()
+    );
+    expect(calculateLaterTodayWakeTime(now, 1, 20)).toBe(
+      new Date('2026-03-18T11:35:00.000Z').getTime()
+    );
+  });
+
   it('uses the configured next week time when calculating the wake time', () => {
     const now = new Date('2026-03-18T10:15:00.000Z');
 
@@ -31,6 +43,7 @@ describe('delayPresets', () => {
       locale: 'en',
       settings: {
         laterToday: 3,
+        laterTodayMinutes: 15,
         tonightTime: '18:00',
         tomorrowTime: '09:00',
         weekendDay: 'saturday',
@@ -42,11 +55,32 @@ describe('delayPresets', () => {
         somedayMinMonths: 3,
         somedayMaxMonths: 12,
       },
-      translate: (key, values) =>
-        `${key}${values ? JSON.stringify(values) : ''}`,
+      translate: (key, values) => {
+        if (key === 'popup.delayOptions.laterToday') {
+          return `In ${String(values?.duration)}`;
+        }
+
+        if (key === 'popup.delayDuration.hours') {
+          return `${String(values?.count)} hours`;
+        }
+
+        if (key === 'popup.delayDuration.minutes') {
+          return `${String(values?.count)} minutes`;
+        }
+
+        return `${key}${values ? JSON.stringify(values) : ''}`;
+      },
     });
 
     expect(options).toHaveLength(7);
+    expect(options[0]).toEqual(
+      expect.objectContaining({
+        id: 'later_today',
+        hours: 3,
+        minutes: 15,
+        label: 'In 3 hours 15 minutes',
+      })
+    );
     expect(options.map((option) => option.id)).toEqual([
       'later_today',
       'tonight',

--- a/src/utils/delayPresets.ts
+++ b/src/utils/delayPresets.ts
@@ -24,9 +24,10 @@ export function parseTimeString(
 
 export function calculateLaterTodayWakeTime(
   now: Date,
-  hours: number
+  hours: number,
+  minutes = 0
 ): number {
-  return now.getTime() + hours * 60 * 60 * 1000;
+  return now.getTime() + (hours * 60 + minutes) * 60 * 1000;
 }
 
 export function calculateTonightWakeTime(
@@ -210,6 +211,36 @@ function getNextMonthLabel(
   return `${translate('popup.delayOptions.nextMonth')} (${formattedDate}, ${formatClockTime(now.getTime(), locale)})`;
 }
 
+function getDurationLabel(
+  hours: number,
+  minutes: number,
+  translate: TranslateFn
+): string {
+  const parts: string[] = [];
+
+  if (hours > 0) {
+    parts.push(
+      translate(
+        hours === 1 ? 'popup.delayDuration.hour' : 'popup.delayDuration.hours',
+        { count: hours }
+      )
+    );
+  }
+
+  if (minutes > 0) {
+    parts.push(
+      translate(
+        minutes === 1
+          ? 'popup.delayDuration.minute'
+          : 'popup.delayDuration.minutes',
+        { count: minutes }
+      )
+    );
+  }
+
+  return parts.join(' ');
+}
+
 export function createPresetDelayOptions(params: {
   locale: string;
   settings: DelaySettings;
@@ -222,11 +253,20 @@ export function createPresetDelayOptions(params: {
     {
       id: 'later_today',
       label: translate('popup.delayOptions.laterToday', {
-        hours: settings.laterToday,
+        duration: getDurationLabel(
+          settings.laterToday,
+          settings.laterTodayMinutes,
+          translate
+        ),
       }),
       hours: settings.laterToday,
+      minutes: settings.laterTodayMinutes,
       calculateTime: () =>
-        calculateLaterTodayWakeTime(new Date(), settings.laterToday),
+        calculateLaterTodayWakeTime(
+          new Date(),
+          settings.laterToday,
+          settings.laterTodayMinutes
+        ),
     },
     {
       id: 'tonight',

--- a/src/utils/extensionStorage.test.ts
+++ b/src/utils/extensionStorage.test.ts
@@ -49,8 +49,23 @@ describe('extensionStorage', () => {
     await expect(getDelaySettings()).resolves.toEqual(
       expect.objectContaining({
         laterToday: 5,
+        laterTodayMinutes: 0,
         nextWeekSameDay: false,
         nextMonthSameDay: true,
+      })
+    );
+  });
+
+  it('normalizes quick delay settings to at least one minute', async () => {
+    localStorage.setItem(
+      'delaySettings',
+      JSON.stringify({ laterToday: 0, laterTodayMinutes: 0 })
+    );
+
+    await expect(getDelaySettings()).resolves.toEqual(
+      expect.objectContaining({
+        laterToday: 0,
+        laterTodayMinutes: 1,
       })
     );
   });


### PR DESCRIPTION
## Summary

This PR improves the tab delay scheduling flow in three related ways:

<details>
<summary>
<h3>Add minute-level configuration for the `Later today` preset</h3>
</summary>
<img width="333" height="168" alt="image" src="https://github.com/user-attachments/assets/88e8a56e-320d-4f3a-a47b-06022f5a00a5" />

</details>

<details>
<summary>
<h3>Default `Custom date & time` to `now + 1 minute`</h3>
</summary>
<img width="326" height="314" alt="image" src="https://github.com/user-attachments/assets/8a10ef9c-85d5-4f88-8e06-c3207810c61a" />

</details>

<details>
<summary>
<h3>Add relative custom delay inputs (`days`, `hours`, `minutes`)</h3>
</summary>
<img width="325" height="575" alt="image" src="https://github.com/user-attachments/assets/a605cbaa-e445-4ddf-a8aa-e734a834d4e6" />

</details>

## Details

### Later today preset
- adds `laterTodayMinutes` to delay settings
- updates options UI to configure both hours and minutes
- updates preset generation so the quick delay can be scheduled with minute precision
- keeps persisted settings backward-compatible through normalization

### Custom delay defaults
- initializes the custom datetime input with the next valid minute instead of `+24h`
- uses local datetime formatting for the `datetime-local` field

### Relative custom delay input
- adds a second input mode for custom delay using:
  - days
  - hours
  - minutes
- keeps the relative fields synchronized with the absolute datetime field
- clamps invalid/past values to the minimum allowed delay when applying the schedule

## Testing

Verified locally with:

- `./node_modules/.bin/vitest run src/utils/dateTime.test.ts src/utils/delayPresets.test.ts src/utils/extensionStorage.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0`

## Notes

This change updates all supported locales: `en`, `es`, and `pt`.