### PR TITLE
feat: Enhance tab opening with precaution notification

### DIFF
--- a/src/background/delayedTabsController.test.ts
+++ b/src/background/delayedTabsController.test.ts
@@ -176,7 +176,7 @@ describe('delayedTabsController', () => {
     );
     const controller = createDelayedTabsController(mock.chromeApi);
 
-    await Promise.all([
+    const wakePromise = Promise.all([
       controller.handleAlarm({
         name: `delayed-tab-${firstTab.id}`,
         scheduledTime: firstTab.wakeTime,
@@ -186,6 +186,8 @@ describe('delayedTabsController', () => {
         scheduledTime: secondTab.wakeTime,
       } as chrome.alarms.Alarm),
     ]);
+    await vi.advanceTimersByTimeAsync(6_000);
+    await wakePromise;
 
     expect(mock.tabsCreate).toHaveBeenCalledTimes(2);
     expect(mock.getStoredTabs()).toEqual([]);
@@ -198,17 +200,24 @@ describe('delayedTabsController', () => {
     const mock = createChromeMock([overdueTab], [`delayed-tab-${overdueTab.id}`]);
     const controller = createDelayedTabsController(mock.chromeApi);
 
-    await controller.handleAlarm({
+    const wakePromise = controller.handleAlarm({
       name: `delayed-tab-${overdueTab.id}`,
       scheduledTime: overdueTab.wakeTime,
     } as chrome.alarms.Alarm);
+    await vi.advanceTimersByTimeAsync(3_000);
+    await wakePromise;
 
     expect(mock.notificationsCreate).toHaveBeenCalledWith({
       type: 'basic',
       iconUrl: 'chrome-extension://delayo/icons/icon128.png',
-      title: 'Tab Awakened!',
-      message: 'Your delayed tab "Example" is now open.',
+      title: 'Tab Waking Up',
+      message: 'Your delayed tab "Example" will open in a few seconds.',
+      priority: 2,
+      requireInteraction: true,
     });
+    expect(mock.notificationsCreate.mock.invocationCallOrder[0]).toBeLessThan(
+      mock.tabsCreate.mock.invocationCallOrder[0]
+    );
   });
 
   it('does not show a notification when a tab is manually woken', async () => {
@@ -334,10 +343,12 @@ describe('delayedTabsController', () => {
     );
     const controller = createDelayedTabsController(mock.chromeApi);
 
-    await controller.handleAlarm({
+    const wakePromise = controller.handleAlarm({
       name: `delayed-tab-${recurringTab.id}`,
       scheduledTime: recurringTab.wakeTime,
     } as chrome.alarms.Alarm);
+    await vi.advanceTimersByTimeAsync(3_000);
+    await wakePromise;
 
     const storedTabs = mock.getStoredTabs();
     expect(mock.tabsCreate).toHaveBeenCalledTimes(1);
@@ -365,10 +376,12 @@ describe('delayedTabsController', () => {
     mock.alarmsCreate.mockRejectedValueOnce(new Error('Failed to create next alarm'));
     const controller = createDelayedTabsController(mock.chromeApi);
 
-    await controller.handleAlarm({
+    const wakePromise = controller.handleAlarm({
       name: `delayed-tab-${recurringTab.id}`,
       scheduledTime: recurringTab.wakeTime,
     } as chrome.alarms.Alarm);
+    await vi.advanceTimersByTimeAsync(3_000);
+    await wakePromise;
 
     expect(mock.tabsCreate).toHaveBeenCalledTimes(1);
     expect(mock.getStoredTabs()).toEqual([

--- a/src/background/delayedTabsController.ts
+++ b/src/background/delayedTabsController.ts
@@ -11,6 +11,7 @@ const DELAYED_TABS_STORAGE_KEY = 'delayedTabs';
 const CONTEXT_MENU_ID = 'delay-tab';
 const ALARM_PREFIX = 'delayed-tab-';
 const NOTIFICATION_ICON_PATH = 'icons/icon128.png';
+const WAKE_NOTIFICATION_LEAD_TIME_MS = 3_000;
 
 type QueueJob<T> = () => Promise<T>;
 type DelayedTabStatus = NonNullable<DelayedTab['status']>;
@@ -18,6 +19,12 @@ type DelayedTabStatus = NonNullable<DelayedTab['status']>;
 interface WakeOptions {
   notify: boolean;
   rescheduleRecurring: boolean;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 function getAlarmName(tabId: string): string {
@@ -198,20 +205,24 @@ export function createDelayedTabsController(
       return;
     }
 
-    await chromeApi.tabs.create({ url: tab.url });
-
     if (notify) {
       try {
         await chromeApi.notifications.create({
           type: 'basic',
           iconUrl: getNotificationIconUrl(chromeApi),
-          title: 'Tab Awakened!',
-          message: `Your ${tab.isRecurring ? 'recurring' : 'delayed'} tab "${tab.title}" is now open.`,
+          title: 'Tab Waking Up',
+          message: `Your ${tab.isRecurring ? 'recurring' : 'delayed'} tab "${tab.title}" will open in a few seconds.`,
+          priority: 2,
+          requireInteraction: true,
         });
       } catch {
         // Notification failures should not roll back the wake flow.
       }
+
+      await delay(WAKE_NOTIFICATION_LEAD_TIME_MS);
     }
+
+    await chromeApi.tabs.create({ url: tab.url });
   }
 
   async function reopenBrowserTabs(tabs: chrome.tabs.Tab[]): Promise<void> {


### PR DESCRIPTION
## Summary

This PR makes delayed tab wake-ups less abrupt when they are triggered by alarms.

Instead of opening the tab immediately, the extension now:
- shows a native warning notification first
- keeps the notification visible with `requireInteraction`
- waits 3 seconds
- opens the delayed tab afterward

Manual wake-ups and startup reconciliation keep their current behavior and do not show this notification.

## Changes

- added a 3-second lead time before opening tabs triggered by alarms
- changed the notification copy from a "tab awakened" confirmation to a "tab waking up" warning
- increased notification visibility with higher priority and `requireInteraction`
- updated tests to cover:
  - notification content
  - notification appearing before tab creation
  - timer-driven delayed opening
  - recurring tab wake behavior with the new delay

## Why

Opening a delayed tab immediately can feel abrupt and disruptive.
Showing a short warning first gives the user a moment of context before the tab appears.

## Testing

- updated `delayedTabsController` tests
- verified that alarm-based wake shows a notification first and opens the tab after the delay
- verified that manual wake still opens without a notification
- verified that recurring wake scenarios still reschedule correctly